### PR TITLE
microbit: Life system handling

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -1,10 +1,13 @@
 #include "MicroBit.h"
 #include "serial_helper.h"
+#include "shift_register_helper.h"
 
 #define LOW 0
 
 MicroBit uBit;
 MicroBitSerial serial(USBTX, USBRX);
+
+MicroBitEvent decrease_lives_evt(DECREASE_LIVES_ID, MICROBIT_EVT_ANY, CREATE_ONLY);
 
 MicroBitPin UP(MICROBIT_ID_IO_P3, MICROBIT_PIN_P3, PIN_CAPABILITY_DIGITAL_IN); // Button Up
 MicroBitPin LEFT(MICROBIT_ID_IO_P0, MICROBIT_PIN_P0, PIN_CAPABILITY_DIGITAL_IN); // Button Left
@@ -12,7 +15,6 @@ MicroBitPin DOWN(MICROBIT_ID_IO_P4, MICROBIT_PIN_P4, PIN_CAPABILITY_DIGITAL_IN);
 MicroBitPin RIGHT(MICROBIT_ID_IO_P6, MICROBIT_PIN_P6, PIN_CAPABILITY_DIGITAL_IN); // Button Right
 MicroBitPin POT(MICROBIT_ID_IO_P1, MICROBIT_PIN_P1, PIN_CAPABILITY_ANALOG_IN); // Potentiometer
 MicroBitPin FAN(MICROBIT_ID_IO_P2, MICROBIT_PIN_P2, PIN_CAPABILITY_ANALOG_IN); // DC Motor fan
-
 
 bool receive = false;  // Whether or not to receive data from the computer
 
@@ -25,6 +27,12 @@ int_fast8_t tmpData = -1;    // Temporary variable used to format multiple chars
 int main() {
   // Initialise the micro:bit runtime.
   uBit.init();
+
+  // Register listener
+  uBit.messageBus.listen(DECREASE_LIVES_ID, MICROBIT_EVT_ANY, decrease_lives);
+
+  // Light up all the LEDs
+  shift_register_all_leds();
 
   while (true) {
     serial.clearTxBuffer();

--- a/source/serial_helper.cpp
+++ b/source/serial_helper.cpp
@@ -1,4 +1,6 @@
+#include "shared_ubit.h"
 #include "serial_helper.h"
+#include "shift_register_helper.h"
 
 #include "MicroBit.h"
 
@@ -34,7 +36,14 @@ bool send(int info[], size_t iterationSize, bool wait) {
       if (mContinue == "Y") {
         return false;
       } else if (mContinue == "R") {
-        return true;
+        if (lives > 0) {
+          lives--;
+          decrease_lives_evt.fire();
+        } else {
+          lives = SHIFTREGISTER_BITS;
+          shift_register_all_leds();
+        }
+        return false;
       }
     } else {
       return false;
@@ -60,7 +69,7 @@ ManagedString receiveMessage() {
   // - 069
   // - 420
   ManagedString size = serial.read(3);
-  uint8_t messageLength;
+  uint8_t messageLength = 0;
   if (size.length() == 3) {
     // Convert to int
     messageLength = atoi(size.toCharArray());

--- a/source/serial_helper.h
+++ b/source/serial_helper.h
@@ -2,7 +2,6 @@
 #define SERIAL_HELPER_H
 #include "MicroBit.h"
 
-extern MicroBit uBit;
 extern MicroBitSerial serial;
 
 extern bool receive;

--- a/source/shared_ubit.h
+++ b/source/shared_ubit.h
@@ -1,0 +1,7 @@
+#ifndef SHARED_UBIT_H
+#define SHARED_UBIT_H
+#include "MicroBit.h"
+
+extern MicroBit uBit;
+
+#endif // SHARED_UBIT_H

--- a/source/shift_register_helper.cpp
+++ b/source/shift_register_helper.cpp
@@ -1,0 +1,37 @@
+#include "shared_ubit.h"
+#include "shift_register_helper.h"
+#include "MicroBit.h"
+
+#define LOW 0
+#define HIGH 1
+
+MicroBitPin SHIFREGISTER_CLOCK(MICROBIT_ID_IO_P14, MICROBIT_PIN_P14, PIN_CAPABILITY_DIGITAL_OUT); // Clock of the shift register
+MicroBitPin SHIFTREGISTER_DATA(MICROBIT_ID_IO_P15, MICROBIT_PIN_P15, PIN_CAPABILITY_DIGITAL_OUT); // Clock serial data
+int8_t lives = SHIFTREGISTER_BITS; // Number of lives / LEDs
+
+void shift_register_all_leds() {
+    // Light up all the LEDs
+    SHIFTREGISTER_DATA.setDigitalValue(HIGH);
+    SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+    for (int i = 0; i < SHIFTREGISTER_BITS; i++) {
+        SHIFREGISTER_CLOCK.setDigitalValue(HIGH);
+        SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+    }
+    SHIFREGISTER_CLOCK.setDigitalValue(HIGH);
+    SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+}
+
+void decrease_lives(MicroBitEvent e) {
+
+    SHIFTREGISTER_DATA.setDigitalValue(LOW);
+    SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+    for (int i = 0; i < SHIFTREGISTER_BITS; i++) {
+        if ((SHIFTREGISTER_BITS - lives) == i) {
+            SHIFTREGISTER_DATA.setDigitalValue(HIGH);
+        }
+        SHIFREGISTER_CLOCK.setDigitalValue(HIGH);
+        SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+    }
+    SHIFREGISTER_CLOCK.setDigitalValue(HIGH);
+    SHIFREGISTER_CLOCK.setDigitalValue(LOW);
+}

--- a/source/shift_register_helper.h
+++ b/source/shift_register_helper.h
@@ -1,0 +1,16 @@
+#ifndef SHIFT_REGISTER_HELPER_H
+#define SHIFT_REGISTER_HELPER_H
+
+#include "MicroBit.h"
+
+#define DECREASE_LIVES_ID 1337
+#define SHIFTREGISTER_BITS 8
+
+extern int8_t lives;
+
+extern MicroBitEvent decrease_lives_evt;
+
+void shift_register_all_leds();
+void decrease_lives(MicroBitEvent e);
+
+#endif // SHIFT_REGISTER_HELPER_H


### PR DESCRIPTION
	* Use a shift register to control 8 LEDs with 2 pins
	* Decrease lives in a different thread using the MicroBit's
	  meesage bus to minimise the possibility of losing serial
	  data or losing sync with the computer.

Signed-off-by: Giuseppe Barillari <joe2k01dev@gmail.com>